### PR TITLE
Separate intro from full text for blog posts

### DIFF
--- a/source/mood/application.d
+++ b/source/mood/application.d
@@ -102,7 +102,7 @@ class MoodApp
             if (entry !is null)
             {
                 auto title = entry.title;
-                auto content = entry.html;
+                auto content = entry.html_full;
                 res.render!("single_post.dt", title, content);
             }
             else

--- a/source/mood/cache/posts.d
+++ b/source/mood/cache/posts.d
@@ -32,6 +32,8 @@ struct BlogPost
     string html_full;
     /// Post creation date
     SysTime created_at;
+    /// Relative path/url for that specific post (also used as cache key)
+    string relative_url;
 
     /**
         Keeps only date part of creation timestamp and formats it in
@@ -64,6 +66,7 @@ struct BlogPost
         import std.regex, std.string;
 
         BlogPost entry;
+        entry.relative_url = key;
         entry.md = src;
         entry.html_full = filterMarkdown(src, MarkdownFlags.backtickCodeBlocks);
 

--- a/views/index.dt
+++ b/views/index.dt
@@ -33,7 +33,8 @@ html.no-js(lang='', xmlns='http://www.w3.org/1999/html')
 				- foreach (post; posts)
 					article.article
 						header
-							h2.title !{ post.title }
+							h2.title
+								a(href='/posts/!{ post.relative_url }') !{ post.title }
 						.content
 							div !{ post.html_intro }
 						footer

--- a/views/index.dt
+++ b/views/index.dt
@@ -35,7 +35,7 @@ html.no-js(lang='', xmlns='http://www.w3.org/1999/html')
 						header
 							h2.title !{ post.title }
 						.content
-							div !{ post.html }
+							div !{ post.html_intro }
 						footer
 							.posted !{ post.pretty_date }
 		footer.Footer


### PR DESCRIPTION
Content should only be rendered fully in dedicated per-post pages. In post feed mode only short intro needs to be displayed. For that some standard means to separate text into parts need to be defined for markdown sources.

Somewhat KISS approach would be to only use paragraphs before first header as an intro.
