### PR TITLE
Support tags / categories

### DIFF
--- a/source/mood/application.d
+++ b/source/mood/application.d
@@ -80,7 +80,29 @@ class MoodApp
         // how many posts to retrieve
         auto n = to!uint(req.query.get("n", "5"));
 
-        auto posts = this.cache.posts_by_date[0 .. (n > $ ? $ : n)];
+        // show only posts with specific tag in feed
+        auto tag_filter = req.query.get("tag", "");
+
+        import std.algorithm : filter;
+        import std.range : take;
+
+        bool hasTag(const BlogPost* post)
+        {
+            if (tag_filter.length == 0)
+                return true;
+
+            foreach (tag; post.tags)
+            {
+                if (tag == tag_filter)
+                    return true;
+            }
+
+            return false;
+        }
+
+        auto posts = this.cache.posts_by_date
+            .filter!hasTag
+            .take(n);
         res.render!("index.dt", posts);
     }
 

--- a/source/mood/cache/posts.d
+++ b/source/mood/cache/posts.d
@@ -26,6 +26,8 @@ struct BlogPost
     string md;
     /// Post title
     string title;
+    /// Array of post tags
+    immutable(char[])[] tags;
     /// Part of rendered blog post HTML used for short preview
     string html_intro;
     /// Full rendered blog post HTML
@@ -100,7 +102,9 @@ struct BlogPost
     // `dst` with it
     private static void parseMetadata(string src, ref BlogPost dst)
     {
-        import std.regex, std.string;
+        import std.regex;
+        import std.string : splitLines;
+        import std.array : split;
 
         static key_value = ctRegex!(r"^([^:]+): (.+)$");
 
@@ -116,6 +120,8 @@ struct BlogPost
                     dst.title = value;
                 else if (key == "Date")
                     dst.created_at = SysTime.fromISOString(value);
+                else if (key == "Tags")
+                    dst.tags = split(value);
             }
         }
     }


### PR DESCRIPTION
Currently mood features single date-ordered blog post feed with no other means of navigation. Support for tags / categories can be implemented even for basic mode as those can be embedded in Markdown metadata easily.
