### PR TITLE
Replace now removed alias parseDietFile with compileDietFile

### DIFF
--- a/source/mood/rendering/html.d
+++ b/source/mood/rendering/html.d
@@ -11,7 +11,7 @@ import vibe.templ.diet;
 
 /**
     Renders index page with a post feed
-    
+
     Params:
         output = stream to write rendered html to
         posts = main blog post feed
@@ -20,12 +20,12 @@ import vibe.templ.diet;
 void renderIndex(OutputStream output, const BlogPost[] posts,
     const BlogPost[] last_posts)
 {
-    parseDietFile!("pages/index.dt", posts, last_posts)(output);
+    compileDietFile!("pages/index.dt", posts, last_posts)(output);
 }
 
 /**
     Renders page with full content for a specific blog post
-    
+
     Params:
         output = stream to write rendered html to
         post = the one
@@ -34,5 +34,5 @@ void renderIndex(OutputStream output, const BlogPost[] posts,
 void renderSinglePost(OutputStream output, const ref BlogPost post,
     const BlogPost[] last_posts)
 {
-    parseDietFile!("pages/single_post.dt", post, last_posts)(output);
+    compileDietFile!("pages/single_post.dt", post, last_posts)(output);
 }


### PR DESCRIPTION
Did a fresh checkout and tried to compile, it failed because `parseDietFile` was removed in v0.7.29: https://github.com/rejectedsoftware/vibe.d/commit/b5ac2c2f6905759260b092cfeba7a8d1435a42e0
